### PR TITLE
Feature/graph move descriptions

### DIFF
--- a/heritageconnector/datastore.py
+++ b/heritageconnector/datastore.py
@@ -71,13 +71,12 @@ def es_bulk(action_generator, total_iterations=None):
 def create(collection, record_type, data, jsonld):
     """Load a new record in ElasticSearch and return its id"""
 
-    # should we make our own ID using the subject URI?
-
     # create a ES doc
     doc = {
         "uri": data["uri"],
         "collection": collection,
         "type": record_type,
+        "data": {i: data[i] for i in data if i != "uri"},
         "graph": json.loads(jsonld),
     }
     es_json = json.dumps(doc)

--- a/smg_jobs/es_to_csv.py
+++ b/smg_jobs/es_to_csv.py
@@ -18,6 +18,10 @@ SELECT ?s ?p ?o WHERE {?s ?p ?o}
 """
 )
 
-with open(file_path, "w", newline="") as f:
-    writer = csv.writer(f, delimiter="\t", quotechar='"')
-    writer.writerows(res)
+# to csv
+# with open(file_path, "w", newline="") as f:
+#     writer = csv.writer(f, delimiter="\t", quotechar='"')
+#     writer.writerows(res)
+
+# to ntriples
+g.serialize(file_path, format="ntriples")

--- a/smg_jobs/smg_loader.py
+++ b/smg_jobs/smg_loader.py
@@ -260,6 +260,9 @@ def serialize_to_json(table_name: str, row: pd.Series, columns: list):
             and bool(row[col])
             and (str(row[col]).lower() != "nan")
         ):
+            # TODO: these lines load description in as https://collection.sciencemuseumgroup.org.uk/objects/co__#<field_name> but for some reason they cause an Elasticsearch timeout
+            # key = row['PREFIX'] + str(row['ID']) + "#" + col.lower()
+            # data[key] = row[col]
             data.update({table_mapping[col]["RDF"]: row[col]})
 
     return data

--- a/smg_jobs/smg_loader.py
+++ b/smg_jobs/smg_loader.py
@@ -249,7 +249,9 @@ def serialize_to_jsonld(table_name: str, uri: str, row: pd.Series):
     table_mapping = field_mapping.mapping[table_name]
 
     keys = {
-        k for k, v in table_mapping.items() if k not in ["ID", "PREFIX"] and "RDF" in v
+        k
+        for k, v in table_mapping.items()
+        if k not in ["ID", "PREFIX"] and "RDF" in v and v.get("PID") != "description"
     }
 
     for col in keys:
@@ -258,7 +260,7 @@ def serialize_to_jsonld(table_name: str, uri: str, row: pd.Series):
         if col not in row.index:
             raise KeyError(f"column {col} not in data for table {table_name}")
 
-        if bool(row[col]) and (str(row[col]) != "nan"):
+        if bool(row[col]) and (str(row[col]).lower() != "nan"):
             if isinstance(row[col], list):
                 [
                     g.add((record, table_mapping[col]["RDF"], Literal(val)))


### PR DESCRIPTION
Fields with type==description in field_mapping are loaded into `doc.data` in an ES document `doc` instead of `doc.graph`. This has reduced the size of the RDF export by 30%.

**Issue:** At the moment the descriptions are still keyed using their RDF value. I wrote the code to put them in the form `https://collection.sciencemuseumgroup.org.uk/objects/co__#<field_name>` but was getting ES timeouts with that for some reason. See commit 95b29a5 / issue #90 