### PR TITLE
Feature/reconcile wikidata columns

### DIFF
--- a/experiments/disambiguation/6. disambiguating place names.ipynb
+++ b/experiments/disambiguation/6. disambiguating place names.ipynb
@@ -1,0 +1,562 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Disambiguating Place Names analysis\n",
+    "\n",
+    "- **people**: BIRTH_PLACE, DEATH_PLACE, OCCUPATION\n",
+    "- **objects**: PLACE_MADE, MATERIALS (via Getty)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append(\"../..\")\n",
+    "import os\n",
+    "\n",
+    "from heritageconnector.config import config\n",
+    "from heritageconnector.utils.data_transformation import transform_series_str_to_list\n",
+    "from heritageconnector.entity_matching.reconciler import reconciler\n",
+    "\n",
+    "from tqdm import tqdm\n",
+    "import pandas as pd\n",
+    "pd.set_option('display.max_colwidth', None)\n",
+    "pd.set_option('display.max_columns', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_pickle(\"../../GITIGNORE_DATA/results/filtering_people_orgs_result.pkl\")\n",
+    "df_people = df[df['GENDER'].isin([\"M\", \"F\"])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Automated\n",
+    "\n",
+    "Place names doesn't work because the idea of a 'place of birth' is too wide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/ipykernel_launcher.py:1: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  \"\"\"Entry point for launching an IPython kernel.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LINK_ID</th>\n",
+       "      <th>PREFERRED_NAME</th>\n",
+       "      <th>TITLE_NAME</th>\n",
+       "      <th>FIRSTMID_NAME</th>\n",
+       "      <th>LASTSUFF_NAME</th>\n",
+       "      <th>SUFFIX_NAME</th>\n",
+       "      <th>HONORARY_SUFFIX</th>\n",
+       "      <th>GENDER</th>\n",
+       "      <th>BRIEF_BIO</th>\n",
+       "      <th>DESCRIPTION</th>\n",
+       "      <th>NOTE</th>\n",
+       "      <th>BIRTH_DATE</th>\n",
+       "      <th>BIRTH_PLACE</th>\n",
+       "      <th>DEATH_DATE</th>\n",
+       "      <th>DEATH_PLACE</th>\n",
+       "      <th>CAUSE_OF_DEATH</th>\n",
+       "      <th>NATIONALITY</th>\n",
+       "      <th>OCCUPATION</th>\n",
+       "      <th>WEBSITE</th>\n",
+       "      <th>AFFILIATION</th>\n",
+       "      <th>LINGUISTIC_GROUP</th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>REFERENCE_NUMBER</th>\n",
+       "      <th>SOURCE</th>\n",
+       "      <th>CREATE_DATE</th>\n",
+       "      <th>UPDATE_DATE</th>\n",
+       "      <th>res_ALL_NOTES</th>\n",
+       "      <th>res_WIKIDATA_IDs</th>\n",
+       "      <th>res_URLS</th>\n",
+       "      <th>qcodes_filtered</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10245</td>\n",
+       "      <td>Zenthon, Edward Rupert</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Edward Rupert</td>\n",
+       "      <td>Zenthon</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>M</td>\n",
+       "      <td>Y</td>\n",
+       "      <td>REF: http://www.iwm.org.uk/collections/item/object/1030031461</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>1920-07</td>\n",
+       "      <td>London, Greater London, England, United Kingdom</td>\n",
+       "      <td>c. 2002</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>British</td>\n",
+       "      <td>[engineer]</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>N</td>\n",
+       "      <td>28-JAN-98</td>\n",
+       "      <td>05-AUG-15</td>\n",
+       "      <td>REF: http://www.iwm.org.uk/collections/item/object/1030031461 --- nan</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>[http://www.iwm.org.uk/collections/item/object/1030031461]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   LINK_ID          PREFERRED_NAME TITLE_NAME  FIRSTMID_NAME LASTSUFF_NAME  \\\n",
+       "1    10245  Zenthon, Edward Rupert        NaN  Edward Rupert       Zenthon   \n",
+       "\n",
+       "  SUFFIX_NAME HONORARY_SUFFIX GENDER BRIEF_BIO  \\\n",
+       "1         NaN             NaN      M         Y   \n",
+       "\n",
+       "                                                     DESCRIPTION NOTE  \\\n",
+       "1  REF: http://www.iwm.org.uk/collections/item/object/1030031461  nan   \n",
+       "\n",
+       "  BIRTH_DATE                                      BIRTH_PLACE DEATH_DATE  \\\n",
+       "1    1920-07  London, Greater London, England, United Kingdom    c. 2002   \n",
+       "\n",
+       "  DEATH_PLACE CAUSE_OF_DEATH NATIONALITY  OCCUPATION WEBSITE  AFFILIATION  \\\n",
+       "1         NaN            NaN     British  [engineer]     NaN          NaN   \n",
+       "\n",
+       "   LINGUISTIC_GROUP TYPE  REFERENCE_NUMBER SOURCE CREATE_DATE UPDATE_DATE  \\\n",
+       "1               NaN  NaN               NaN      N   28-JAN-98   05-AUG-15   \n",
+       "\n",
+       "                                                           res_ALL_NOTES  \\\n",
+       "1  REF: http://www.iwm.org.uk/collections/item/object/1030031461 --- nan   \n",
+       "\n",
+       "  res_WIKIDATA_IDs  \\\n",
+       "1               []   \n",
+       "\n",
+       "                                                     res_URLS qcodes_filtered  \n",
+       "1  [http://www.iwm.org.uk/collections/item/object/1030031461]              []  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_people['OCCUPATION'] = transform_series_str_to_list(df_people['OCCUPATION'], separator=\";\")\n",
+    "\n",
+    "df_people.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/ipykernel_launcher.py:1: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  \"\"\"Entry point for launching an IPython kernel.\n",
+      "  0%|          | 0/26 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking up Wikidata qcodes for unique items..\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 26/26 [00:13<00:00,  1.97it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1      []\n",
+       "2      []\n",
+       "3      []\n",
+       "4      []\n",
+       "5      []\n",
+       "       ..\n",
+       "201    []\n",
+       "204    []\n",
+       "209    []\n",
+       "211    []\n",
+       "214    []\n",
+       "Name: BIRTH_PLACE, Length: 100, dtype: object"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_people[\"BIRTH_PLACE\"] = df_people[\"BIRTH_PLACE\"].fillna(\"\")\n",
+    "testdf = df_people.head(100)\n",
+    "rec = reconciler(testdf, table=\"PERSON\")\n",
+    "\n",
+    "#df_people[\"OCCUPATION_qids\"] = rec.process_column(\"OCCUPATION\", multiple_vals=True)\n",
+    "rec.process_column(\"BIRTH_PLACE\", multiple_vals=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Q958822', 'Q1322263']"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lookup_filter = reconciler.get_subject_items_from_pid(\"P19\")\n",
+    "lookup_filter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. Manual\n",
+    "\n",
+    "**Result:** look ups aren't working because the *instanceof_filter* defined using the PID isn't correct. When trying to use a high-level filter (see below), the results are too varied.\n",
+    "\n",
+    "**Next step:** this is an NLP problem: geocoding. We can frame it as an entity linking problem instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from heritageconnector.disambiguation.search import wikidata_text_search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = wikidata_text_search()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rank</th>\n",
+       "      <th>item</th>\n",
+       "      <th>itemLabel</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q1350565</td>\n",
+       "      <td>Germany</td>\n",
+       "      <td>0.142857</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q1011486</td>\n",
+       "      <td>Burg Drachenfels</td>\n",
+       "      <td>0.131868</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49289431</td>\n",
+       "      <td>Setzingen</td>\n",
+       "      <td>0.120879</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q2268218</td>\n",
+       "      <td>Geilenkirchen-Heinsberg</td>\n",
+       "      <td>0.109890</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q55134129</td>\n",
+       "      <td>Germany</td>\n",
+       "      <td>0.098901</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49292935</td>\n",
+       "      <td>Werda</td>\n",
+       "      <td>0.087912</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49292059</td>\n",
+       "      <td>Undenheim</td>\n",
+       "      <td>0.076923</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q16855868</td>\n",
+       "      <td>Pädagogische Hochschule Erfurt/Mühlhausen</td>\n",
+       "      <td>0.065934</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>9</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q7033</td>\n",
+       "      <td>Nordhausen</td>\n",
+       "      <td>0.054945</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>10</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q183</td>\n",
+       "      <td>Germany</td>\n",
+       "      <td>0.043956</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>11</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49289365</td>\n",
+       "      <td>Schönwalde am Bungsberg</td>\n",
+       "      <td>0.032967</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>12</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q28738542</td>\n",
+       "      <td>Bundesverband der Betriebskrankenkassen</td>\n",
+       "      <td>0.021978</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>13</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49283840</td>\n",
+       "      <td>Gölenkamp</td>\n",
+       "      <td>0.010989</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>14</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q49285050</td>\n",
+       "      <td>Kloster Vessra</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    rank                                      item  \\\n",
+       "0      1   http://www.wikidata.org/entity/Q1350565   \n",
+       "1      2   http://www.wikidata.org/entity/Q1011486   \n",
+       "2      3  http://www.wikidata.org/entity/Q49289431   \n",
+       "3      4   http://www.wikidata.org/entity/Q2268218   \n",
+       "4      5  http://www.wikidata.org/entity/Q55134129   \n",
+       "5      6  http://www.wikidata.org/entity/Q49292935   \n",
+       "6      7  http://www.wikidata.org/entity/Q49292059   \n",
+       "7      8  http://www.wikidata.org/entity/Q16855868   \n",
+       "8      9      http://www.wikidata.org/entity/Q7033   \n",
+       "9     10       http://www.wikidata.org/entity/Q183   \n",
+       "10    11  http://www.wikidata.org/entity/Q49289365   \n",
+       "11    12  http://www.wikidata.org/entity/Q28738542   \n",
+       "12    13  http://www.wikidata.org/entity/Q49283840   \n",
+       "13    14  http://www.wikidata.org/entity/Q49285050   \n",
+       "\n",
+       "                                    itemLabel     score  \n",
+       "0                                     Germany  0.142857  \n",
+       "1                            Burg Drachenfels  0.131868  \n",
+       "2                                   Setzingen  0.120879  \n",
+       "3                     Geilenkirchen-Heinsberg  0.109890  \n",
+       "4                                     Germany  0.098901  \n",
+       "5                                       Werda  0.087912  \n",
+       "6                                   Undenheim  0.076923  \n",
+       "7   Pädagogische Hochschule Erfurt/Mühlhausen  0.065934  \n",
+       "8                                  Nordhausen  0.054945  \n",
+       "9                                     Germany  0.043956  \n",
+       "10                    Schönwalde am Bungsberg  0.032967  \n",
+       "11    Bundesverband der Betriebskrankenkassen  0.021978  \n",
+       "12                                  Gölenkamp  0.010989  \n",
+       "13                             Kloster Vessra  0.000000  "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "search.run_search(\"Germany\", instanceof_filter=[\"Q2221906\"], include_class_tree=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manual labelling\n",
+    "\n",
+    "24% of birth places can also be obtained through manual labelling of only the 100 top place names. ~50% of the collection doesn't have a birth place so this is equivalent to 50%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "24.082302936630605"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_labelled = 100\n",
+    "(df_people.loc[df_people['BIRTH_PLACE'] != \"\", 'BIRTH_PLACE'].value_counts() / len(df_people) * 100)[0:n_labelled].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/heritageconnector/entity_matching/reconciler.py
+++ b/heritageconnector/entity_matching/reconciler.py
@@ -21,7 +21,7 @@ class reconciler:
         Retrieves the column PID from field mapping config. Returns None if one is not present.
         """
 
-        config_table = field_mapping.__dict__[self.table]
+        config_table = field_mapping.mapping[self.table]
 
         if column not in config_table:
             raise KeyError(
@@ -43,8 +43,18 @@ class reconciler:
     def get_subject_items_from_pid(pid: str) -> list:
         """
         Gets a list of subject items from a Wikidata property ID using 'subject
-        item of this property (P1629)'.
+        item of this property (P1629)'. If a URL is passed extracts the PID from 
+        it if it exists, else raises a ValueError.
         """
+
+        if pid.startswith("http"):
+            # print("WARNING: URL instead of PID entered. Converting to PID")
+            pids = re.findall(r"(P\d+)", pid)
+
+            if len(pids) == 1:
+                pid = pids[0]
+            else:
+                raise ValueError("URL not a valid property URL.")
 
         query = f"""
         SELECT ?property WHERE {{

--- a/heritageconnector/entity_matching/reconciler.py
+++ b/heritageconnector/entity_matching/reconciler.py
@@ -123,5 +123,5 @@ class reconciler:
             )
         else:
             return self.df[column].apply(
-                lambda x: map_df.loc[x, "qid"].values if x != "" else []
+                lambda x: map_df.loc[x, "qid"] if x != "" else []
             )

--- a/heritageconnector/utils/sparql.py
+++ b/heritageconnector/utils/sparql.py
@@ -21,16 +21,14 @@ def get_sparql_results(endpoint_url: str, query: str) -> dict:
     sparql.setMethod("POST")
     sparql.setReturnFormat(JSON)
     sparql.addCustomHttpHeader(
-        "User-Agent",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36",
+        "User-Agent", "Heritage Connector/0.1 (Science Museum Group)",
     )
     try:
         return sparql.query().convert()
     except urllib.error.HTTPError as e:
         if e.code == 429:
-            if "retry-after" in e.headers:
-                if isinstance(e.headers["retry-after"], int):
-                    time.sleep(e.headers["retry-after"])
+            if isinstance(e.headers.get("retry-after", None), int):
+                time.sleep(e.headers["retry-after"])
             else:
                 time.sleep(10)
             return get_sparql_results(endpoint_url, query)


### PR DESCRIPTION
- fixed reconciler in line with new `field_mapping` config 
- fixed reconciler being slow (new user agent & fix time.sleep)
- experiment disambiguating places -> we should treat this as an NLP exercise instead

Reconciling occupations (Wikidata) and materials (Getty) works well but I haven't found a benefit of pushing those links to the graph yet