### PR TITLE
generate custom user-agent according to wikidata guidelines

### DIFF
--- a/config/config.sample.ini
+++ b/config/config.sample.ini
@@ -4,8 +4,9 @@ MIMSY_PEOPLE_PATH = ../GITIGNORE_DATA/smg-datasets-private/mimsy-people-export.c
 MIMSY_MAKER_PATH = ../GITIGNORE_DATA/smg-datasets-private/items_makers.csv
 MIMSY_USER_PATH = ../GITIGNORE_DATA/smg-datasets-private/items_users.csv
 
-[URLs]
+[WIKIDATA]
 WIKIDATA_SPARQL_ENDPOINT = https://query.wikidata.org/sparql
+CUSTOM_USER_AGENT = <contact-details-go-here>
 
 [ELASTIC]
 ELASTIC_SEARCH_CLUSTER = https://xxxx.eu-west-1.aws.found.io:9243/


### PR DESCRIPTION
fyi @jamieu 

Better user agent header for SPARQL queries which follows [Wikidata policy](https://meta.wikimedia.org/wiki/User-Agent_policy) with option for custom contact details in config.ini

closes #112 