### PR TITLE
Types wikidata urls in loader

### DIFF
--- a/experiments/reconciling object and organisation types.ipynb
+++ b/experiments/reconciling object and organisation types.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reconciling Object & Organisation Types\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:670: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
+      "  from pandas import Panel\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append(\"../..\")\n",
+    "import os\n",
+    "\n",
+    "from heritageconnector.config import config\n",
+    "from heritageconnector.utils.data_transformation import transform_series_str_to_list\n",
+    "from heritageconnector.entity_matching.reconciler import reconciler\n",
+    "\n",
+    "from tqdm import tqdm\n",
+    "import pandas as pd\n",
+    "pd.set_option('display.max_colwidth', None)\n",
+    "pd.set_option('display.max_columns', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_pickle(\"../../GITIGNORE_DATA/results/filtering_people_orgs_result.pkl\")\n",
+    "# df_people = df[df['GENDER'].isin([\"M\", \"F\"])]\n",
+    "df_orgs = df[df['GENDER'] == \"N\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "org_type_col = \"OCCUPATION\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/pandas/core/indexing.py:1745: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  isetter(ilocs[0], value)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_orgs.loc[:, org_type_col] = df_orgs.loc[:, org_type_col].str.replace(\"'\", \"\")\n",
+    "df_orgs.loc[:, org_type_col] = transform_series_str_to_list(df_orgs[org_type_col], separator=\";\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        [manufacturer of mathematical instruments]\n",
+       "6                                   [railway board]\n",
+       "8                                        [supplier]\n",
+       "12                         [training establishment]\n",
+       "14           [manufacturer of electrical equipment]\n",
+       "                            ...                    \n",
+       "18053                                    [hospital]\n",
+       "18061                                            []\n",
+       "18067                      [designer, manufacturer]\n",
+       "18068                                [manufacturer]\n",
+       "18076                                            []\n",
+       "Name: OCCUPATION, Length: 7743, dtype: object"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_orgs[org_type_col]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-09-29 11:20:11,964 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for unique items..\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 92/92 [00:34<00:00,  2.68it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "rec = reconciler(df_orgs.head(100), table=\"ORGANISATION\")\n",
+    "resdf = rec.process_column(org_type_col, multiple_vals=True, instanceof_filter=\"Q43229\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>qid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>manufacturer of mathematical instruments</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>railway board</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>supplier</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>training establishment</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>manufacturer of electrical equipment</th>\n",
+       "      <td>4</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linear measure maker</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>textile manufacturer</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>glass manufacturer</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cotton milling</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>clothing manufacturer</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>92 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          count qid\n",
+       "manufacturer of mathematical instruments      1  []\n",
+       "railway board                                 1  []\n",
+       "supplier                                      1  []\n",
+       "training establishment                        1  []\n",
+       "manufacturer of electrical equipment          4  []\n",
+       "...                                         ...  ..\n",
+       "linear measure maker                          1  []\n",
+       "textile manufacturer                          1  []\n",
+       "glass manufacturer                            1  []\n",
+       "cotton milling                                1  []\n",
+       "clothing manufacturer                         1  []\n",
+       "\n",
+       "[92 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rec._map_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/wikidata_test.py
+++ b/wikidata_test.py
@@ -1,0 +1,86 @@
+from heritageconnector.utils.sparql import get_sparql_results
+from heritageconnector.config import config
+
+endpoint = config.WIKIDATA_SPARQL_ENDPOINT
+
+
+def test_entitysearch_query():
+    query = """SELECT DISTINCT ?item ?itemLabel 
+    WHERE
+    {
+        ?item wdt:P31/wdt:P279* wd:Q43229.
+        SERVICE wikibase:mwapi {
+            bd:serviceParam wikibase:api "EntitySearch" .
+            bd:serviceParam wikibase:endpoint "www.wikidata.org" .
+            bd:serviceParam mwapi:search "bank" .
+            bd:serviceParam mwapi:language "en" .
+            ?item wikibase:apiOutputItem mwapi:item .
+            ?num wikibase:apiOrdinal true .
+            }
+
+        SERVICE wikibase:label {
+        bd:serviceParam wikibase:language "en" .
+        }
+    }"""
+
+    res = get_sparql_results(endpoint, query)
+
+    # more than one result returned
+    assert len(res["results"]["bindings"]) > 0
+
+
+def test_shortestpath_query():
+    query = """PREFIX gas: <http://www.bigdata.com/rdf/gas#>
+
+    SELECT ?super (?aLength + ?bLength as ?length) WHERE {
+    SERVICE gas:service {
+        gas:program gas:gasClass "com.bigdata.rdf.graph.analytics.SSSP" ;
+                    gas:in wd:Q22687 ;
+                    gas:traversalDirection "Forward" ;
+                    gas:out ?super ;
+                    gas:out1 ?aLength ;
+                    gas:maxIterations 10 ;
+                    gas:linkType wdt:P279 .
+    }
+    SERVICE gas:service {
+        gas:program gas:gasClass "com.bigdata.rdf.graph.analytics.SSSP" ;
+                    gas:in wd:Q43229 ;
+                    gas:traversalDirection "Forward" ;
+                    gas:out ?super ;
+                    gas:out1 ?bLength ;
+                    gas:maxIterations 10 ;
+                    gas:linkType wdt:P279 .
+    }  
+    } ORDER BY ?length
+    LIMIT 1"""
+
+    res = get_sparql_results(endpoint, query)
+    assert int(float(res["results"]["bindings"][0]["length"]["value"])) == 2
+
+
+def test_propertylookup_query():
+    query = """
+    SELECT ?item ?itemLabel ?itemDescription ?altLabel ?P570Label ?P569Label
+    WHERE {
+        VALUES (?item) { (wd:Q106481) (wd:Q46633) }
+        OPTIONAL{ ?item wdt:P570 ?P570 .}
+        OPTIONAL{ ?item wdt:P569 ?P569 .}
+
+        OPTIONAL {
+        ?item skos:altLabel ?altLabel .
+        FILTER (lang(?altLabel) = "en")
+        }
+
+        SERVICE wikibase:label { 
+        bd:serviceParam wikibase:language "en" .
+        }
+    }
+    """
+
+    res = get_sparql_results(endpoint, query)
+
+    # one result for each entity
+    assert len(res["results"]["bindings"]) == 2
+
+    # one column for each value in the SELECT slug
+    assert len(res["results"]["bindings"][0]) == 6


### PR DESCRIPTION
- updated reconciler to work with custom PIDs/QIDs
- loading sameAs links from Wikidata using [described at URL](https://www.wikidata.org/wiki/Property:P973) property
- wrote tests for common SPARQL queries

Merging now so I can proceed with #132: rewriting the reconciler to use our Elasticsearch index rather than EntitySearch in SPARQL

fyi @jamieu 