### PR TITLE
Add reconciled object & organisation types to loader

### DIFF
--- a/config/config.sample.ini
+++ b/config/config.sample.ini
@@ -1,4 +1,5 @@
 [DATA]
+DATA_FOLDER = ../GITIGNORE_DATA
 MIMSY_CATALOGUE_PATH = ../GITIGNORE_DATA/smg-datasets-private/mimsy-catalogue-export.csv
 MIMSY_PEOPLE_PATH = ../GITIGNORE_DATA/smg-datasets-private/mimsy-people-export.csv
 MIMSY_MAKER_PATH = ../GITIGNORE_DATA/smg-datasets-private/items_makers.csv

--- a/experiments/reconciling object and organisation types.ipynb
+++ b/experiments/reconciling object and organisation types.ipynb
@@ -155,46 +155,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:706: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
-      "  from pandas import Panel\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "rec.import_map_df(\"../GITIGNORE_DATA/reconciliation_ORGANISATION_20201006.csv\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:706: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
-      "  from pandas import Panel\n"
+      "100%|██████████| 7743/7743 [00:03<00:00, 2555.93it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "82% of records have at least one resolved type\n"
+      "32% of records have at least one resolved type\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\n",
       "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/ipykernel_launcher.py:3: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
@@ -213,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -255,7 +246,7 @@
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>[supplier]</td>\n",
-       "      <td>['Q7644488']</td>\n",
+       "      <td>[Q7644488]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
@@ -275,7 +266,7 @@
        "    <tr>\n",
        "      <th>18053</th>\n",
        "      <td>[hospital]</td>\n",
-       "      <td>['Q180370', 'Q16917']</td>\n",
+       "      <td>[Q180370, Q16917]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>18061</th>\n",
@@ -303,23 +294,23 @@
        "</div>"
       ],
       "text/plain": [
-       "                                       OCCUPATION    OCCUPATION_resolved\n",
-       "0      [manufacturer of mathematical instruments]                     []\n",
-       "6                                 [railway board]                     []\n",
-       "8                                      [supplier]           ['Q7644488']\n",
-       "12                       [training establishment]                     []\n",
-       "14         [manufacturer of electrical equipment]                     []\n",
-       "...                                           ...                    ...\n",
-       "18053                                  [hospital]  ['Q180370', 'Q16917']\n",
-       "18061                                          []                     []\n",
-       "18067                    [designer, manufacturer]                     []\n",
-       "18068                              [manufacturer]                     []\n",
-       "18076                                          []                     []\n",
+       "                                       OCCUPATION OCCUPATION_resolved\n",
+       "0      [manufacturer of mathematical instruments]                  []\n",
+       "6                                 [railway board]                  []\n",
+       "8                                      [supplier]          [Q7644488]\n",
+       "12                       [training establishment]                  []\n",
+       "14         [manufacturer of electrical equipment]                  []\n",
+       "...                                           ...                 ...\n",
+       "18053                                  [hospital]   [Q180370, Q16917]\n",
+       "18061                                          []                  []\n",
+       "18067                    [designer, manufacturer]                  []\n",
+       "18068                              [manufacturer]                  []\n",
+       "18076                                          []                  []\n",
        "\n",
        "[7743 rows x 2 columns]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -364,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,32 +428,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 282259/282259 [01:35<00:00, 2953.88it/s]\n"
+      "100%|██████████| 282259/282259 [01:37<00:00, 2894.75it/s]\n"
      ]
     }
    ],
    "source": [
-    "rec_o.import_map_df()\n",
+    "rec_o.multiple_vals = True # hacky\n",
+    "rec_o.import_map_df(\"../GITIGNORE_DATA/reconciliation_OBJECT_20201006-1309.csv\")\n",
     "objects[\"ITEM_NAME_resolved\"] = rec_o.create_column_from_map_df(\"ITEM_NAME\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "86% of records have at least one resolved type\n"
+      "51% of records have at least one resolved type\n"
      ]
     }
    ],
@@ -472,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/experiments/reconciling object and organisation types.ipynb
+++ b/experiments/reconciling object and organisation types.ipynb
@@ -99,21 +99,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-10-02 16:28:22,944 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n"
+      "2020-10-06 10:17:32,831 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 2603/2603 [06:02<00:00,  7.17it/s]"
+      "100%|██████████| 2603/2603 [13:10<00:00,  3.29it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-10-02 16:34:25,878 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of ['Q43229', 'Q28640']\n"
+      "2020-10-06 10:30:43,802 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of ['Q43229', 'Q28640']\n"
      ]
     },
     {
@@ -121,50 +121,220 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "100%|██████████| 58/58 [00:34<00:00,  1.69it/s]\n",
-      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/ipykernel_launcher.py:6: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  \n"
+      "100%|██████████| 11/11 [00:05<00:00,  1.87it/s]\n"
      ]
     }
    ],
    "source": [
     "rec = reconciler(df_orgs, table=\"ORGANISATION\")\n",
-    "df_orgs[\"OCCUPATION_resolved\"] = rec.process_column(org_type_col,\n",
-    "                                                    multiple_vals=True, \n",
-    "                                                    class_include=[\"Q43229\", \"Q28640\"], \n",
-    "                                                    text_similarity_thresh=95,\n",
-    "                                                    search_limit_per_item=500)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "24% of records have at least one resolved type\n"
-     ]
-    }
-   ],
-   "source": [
-    "#df_orgs[[org_type_col, \"OCCUPATION_resolved\"]]#.head()\n",
-    "print(f\"{int((df_orgs['OCCUPATION_resolved'].apply(len) > 0).sum() / len(df_orgs) * 100)}% of records have at least one resolved type\")"
+    "rec.process_column(org_type_col,\n",
+    "                    multiple_vals=True, \n",
+    "                    class_include=[\"Q43229\", \"Q28640\"], \n",
+    "                    text_similarity_thresh=95,\n",
+    "                    search_limit_per_item=1000,\n",
+    "                    field_exists_filter=\"claims.P279\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:706: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
+      "  from pandas import Panel\n"
+     ]
+    }
+   ],
+   "source": [
+    "rec.export_map_df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:706: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
+      "  from pandas import Panel\n"
+     ]
+    }
+   ],
+   "source": [
+    "rec.import_map_df(\"../GITIGNORE_DATA/reconciliation_ORGANISATION_20201006.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/tqdm/std.py:706: FutureWarning: The Panel class is removed from pandas. Accessing it from the top-level namespace will also be removed in the next version\n",
+      "  from pandas import Panel\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "82% of records have at least one resolved type\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kalyan/.local/share/virtualenvs/heritage-connector-tkmarX41/lib/python3.7/site-packages/ipykernel_launcher.py:3: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  This is separate from the ipykernel package so we can avoid doing imports until\n"
+     ]
+    }
+   ],
+   "source": [
+    "#df_orgs[[org_type_col, \"OCCUPATION_resolved\"]]#.head()\n",
+    "rec.multiple_vals = True\n",
+    "df_orgs[\"OCCUPATION_resolved\"] = rec.create_column_from_map_df(\"OCCUPATION\")\n",
+    "print(f\"{int((df_orgs['OCCUPATION_resolved'].apply(len) > 0).sum() / len(df_orgs) * 100)}% of records have at least one resolved type\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>OCCUPATION</th>\n",
+       "      <th>OCCUPATION_resolved</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[manufacturer of mathematical instruments]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>[railway board]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>[supplier]</td>\n",
+       "      <td>['Q7644488']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>[training establishment]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>[manufacturer of electrical equipment]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18053</th>\n",
+       "      <td>[hospital]</td>\n",
+       "      <td>['Q180370', 'Q16917']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18061</th>\n",
+       "      <td>[]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18067</th>\n",
+       "      <td>[designer, manufacturer]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18068</th>\n",
+       "      <td>[manufacturer]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18076</th>\n",
+       "      <td>[]</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>7743 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                       OCCUPATION    OCCUPATION_resolved\n",
+       "0      [manufacturer of mathematical instruments]                     []\n",
+       "6                                 [railway board]                     []\n",
+       "8                                      [supplier]           ['Q7644488']\n",
+       "12                       [training establishment]                     []\n",
+       "14         [manufacturer of electrical equipment]                     []\n",
+       "...                                           ...                    ...\n",
+       "18053                                  [hospital]  ['Q180370', 'Q16917']\n",
+       "18061                                          []                     []\n",
+       "18067                    [designer, manufacturer]                     []\n",
+       "18068                              [manufacturer]                     []\n",
+       "18076                                          []                     []\n",
+       "\n",
+       "[7743 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_orgs[[\"OCCUPATION\", \"OCCUPATION_resolved\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "df_orgs.to_pickle(\"./df_orgs.pkl\")"
+    "# df_orgs.to_pickle(\"../GITIGNORE_DATA/organisations_with_types.pkl\")"
    ]
   },
   {
@@ -176,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -194,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,31 +373,203 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 11:37:17,009 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 23600/23600 [1:29:23<00:00,  4.40it/s]  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 13:06:40,519 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of Q223557\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 118/118 [02:24<00:00,  1.22s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "rec_o = reconciler(objects, table=\"OBJECT\")\n",
     "# physical object\n",
-    "objects[\"ITEM_NAME_resolved\"] = rec_o.process_column(\"ITEM_NAME\", multiple_vals=True, class_include=\"Q223557\", class_exclude=[\"Q5\", \"Q43229\", \"Q28640\"], text_similarity_thresh=95)"
+    "rec_o.process_column(\"ITEM_NAME\", \n",
+    "                     multiple_vals=True, \n",
+    "                     class_include=\"Q223557\", \n",
+    "                     class_exclude=[\"Q5\", \"Q43229\", \"Q28640\"], \n",
+    "                     text_similarity_thresh=90,\n",
+    "                     search_limit_per_item=1000,\n",
+    "                     field_exists_filter=\"claims.P279\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 13:09:05,126 - heritageconnector.entity_matching.reconciler - INFO - Dataframe of value to entity mappings exported to ../GITIGNORE_DATA/reconciliation_OBJECT_20201006-1309.csv\n",
+      "2020-10-06 13:09:05,126 - heritageconnector.entity_matching.reconciler - INFO - Dataframe of value to entity mappings exported to ../GITIGNORE_DATA/reconciliation_OBJECT_20201006-1309.csv\n"
+     ]
+    }
+   ],
    "source": [
-    "objects[['ITEM_NAME', 'ITEM_NAME_resolved']]"
+    "rec_o.export_map_df()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 282259/282259 [01:35<00:00, 2953.88it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "rec_o.import_map_df()\n",
+    "objects[\"ITEM_NAME_resolved\"] = rec_o.create_column_from_map_df(\"ITEM_NAME\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "86% of records have at least one resolved type\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"{int((objects['ITEM_NAME_resolved'].apply(len) > 0).sum() / len(objects) * 100)}% of records have at least one resolved type\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# objects.to_pickle(\"../GITIGNORE_DATA/objects_with_types.pkl\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 15:13:31,286 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n",
+      "2020-10-06 15:13:31,286 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n",
+      "2020-10-06 15:13:31,286 - heritageconnector.entity_matching.reconciler - INFO - Looking up Wikidata qcodes for items on Elasticsearch Wikidata dump\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 5/5 [00:00<00:00,  6.98it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 15:13:32,008 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of Q223557\n",
+      "2020-10-06 15:13:32,008 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of Q223557\n",
+      "2020-10-06 15:13:32,008 - heritageconnector.entity_matching.reconciler - INFO - Filtering to values in subclass tree of Q223557\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "100%|██████████| 1/1 [00:00<00:00,  1.29it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-10-06 15:13:32,788 - heritageconnector.entity_matching.reconciler - WARNING - Using automatically generated mapping table. It is recommended to run `export_map_df`and manually inspect the reconciled entities before adding them back to your data.\n",
+      "2020-10-06 15:13:32,788 - heritageconnector.entity_matching.reconciler - WARNING - Using automatically generated mapping table. It is recommended to run `export_map_df`and manually inspect the reconciled entities before adding them back to your data.\n",
+      "2020-10-06 15:13:32,788 - heritageconnector.entity_matching.reconciler - WARNING - Using automatically generated mapping table. It is recommended to run `export_map_df`and manually inspect the reconciled entities before adding them back to your data.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "100%|██████████| 5/5 [00:00<00:00, 4468.68it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0              [Q125191]\n",
+       "1    [Q15328, Q97301845]\n",
+       "2            [Q57312861]\n",
+       "3               [Q80228]\n",
+       "4               [Q80228]\n",
+       "Name: item_name, dtype: object"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = pd.DataFrame.from_dict({\"item_name\": [\"photograph\", \"camera\", \"model\", \"bottle\", \"bottles\"]})\n",
+    "\n",
+    "r = reconciler(data, table=\"OBJECT\")\n",
+    "r.process_column(\"item_name\",\n",
+    "                 multiple_vals=False, \n",
+    "                 class_include=\"Q223557\", \n",
+    "                 class_exclude=[\"Q5\", \"Q43229\", \"Q28640\"], \n",
+    "                 text_similarity_thresh=90,\n",
+    "                 search_limit_per_item=1000,\n",
+    "                 field_exists_filter=\"claims.P279\")\n",
+    "\n",
+    "r.create_column_from_map_df(\"item_name\")"
    ]
   },
   {

--- a/heritageconnector/entity_matching/reconciler.py
+++ b/heritageconnector/entity_matching/reconciler.py
@@ -85,6 +85,7 @@ class reconciler:
         class_exclude: Union[str, list] = None,
         search_limit_per_item: int = 5000,
         text_similarity_thresh: int = 95,
+        field_exists_filter: str = None,
     ) -> pd.Series:
         """
         Run reconciliation on a categorical column.
@@ -103,6 +104,9 @@ class reconciler:
                 Set lower (~200) for speed if queries are more unique. With a small limit some results for generic
                 queries may be missed. Defaults to 5000.
             text_similarity_thresh (int). Text similarity threshold for a match. Defaults to 95.
+            field_exists_filter (str, optional): if specified, all searches will be filtered to only documents which have a value for this field.
+                For example to filter to documents which have a P279 value, set `field_exists_filter = "claims.P279"`. Defaults to None.
+
         """
 
         if column not in self.df.columns:
@@ -137,6 +141,7 @@ class reconciler:
                 limit=search_limit_per_item,
                 return_instanceof=False,
                 similarity_thresh=text_similarity_thresh,
+                field_exists_filter=field_exists_filter,
             )
 
             return qids

--- a/heritageconnector/entity_matching/reconciler.py
+++ b/heritageconnector/entity_matching/reconciler.py
@@ -2,10 +2,11 @@ import re
 import pandas as pd
 from collections import Counter
 from tqdm import tqdm
+import os
 from typing import Union
 from heritageconnector.disambiguation.search import es_text_search
 from heritageconnector.config import config, field_mapping
-from heritageconnector.utils.generic import paginate_list
+from heritageconnector.utils.generic import paginate_list, get_timestamp
 from heritageconnector.utils.sparql import get_sparql_results
 from heritageconnector.utils.wikidata import url_to_qid, filter_qids_in_class_tree
 from heritageconnector import logging
@@ -19,6 +20,9 @@ class reconciler:
     def __init__(self, dataframe: pd.DataFrame, table: str):
         self.df = dataframe
         self.table = table.upper()
+
+        self._map_df = None
+        self._map_df_imported = None
 
     def get_column_pid(self, column: str) -> str:
         """
@@ -47,12 +51,12 @@ class reconciler:
     def get_subject_items_from_pid(pid: str) -> list:
         """
         Gets a list of subject items from a Wikidata property ID using 'subject
-        item of this property (P1629)'. If a URL is passed extracts the PID from 
+        item of this property (P1629)'. If a URL is passed extracts the PID from
         it if it exists, else raises a ValueError.
         """
 
         if pid.startswith("http"):
-            logger.warn("WARNING: URL instead of PID entered. Converting to PID")
+            logger.warning("WARNING: URL instead of PID entered. Converting to PID")
             pids = re.findall(r"(P\d+)", pid)
 
             if len(pids) == 1:
@@ -92,11 +96,11 @@ class reconciler:
 
         Args:
             column (str): column to reconcile.
-            multiple_vals (bool): whether the column contains multiple values per record. 
+            multiple_vals (bool): whether the column contains multiple values per record.
                 If values are: lists -> True, strings -> False.
-            pid (str, Optional): Wikidata PID of the selected column. Only needed to look up a class 
+            pid (str, Optional): Wikidata PID of the selected column. Only needed to look up a class
                 constraint using 'subject item of this property' (P1629).
-            class_include (Union[str, list], Optional): class tree to look under. Will be ignored if 
+            class_include (Union[str, list], Optional): class tree to look under. Will be ignored if
                 PID is specified. Defaults to None.
             class_exclude (Union[str, list], Optional): class trees containing this class (above the entity)
                 will be excluded. Defaults to None.
@@ -108,6 +112,8 @@ class reconciler:
                 For example to filter to documents which have a P279 value, set `field_exists_filter = "claims.P279"`. Defaults to None.
 
         """
+
+        self.multiple_vals = multiple_vals
 
         if column not in self.df.columns:
             raise ValueError("Column not in dataframe columns.")
@@ -152,7 +158,6 @@ class reconciler:
         )
 
         map_df["qids"] = map_df.index.to_series().progress_apply(lookup_value)
-        self._map_df = map_df
 
         # get set of types to look up in subclass tree
         instanceof_unique = set(map_df["qids"].sum())
@@ -179,33 +184,80 @@ class reconciler:
 
         self._map_df = map_df
 
-        return self.create_column_from_map_df(column, map_df, multiple_vals)
+        # return self.create_column_from_map_df(column, map_df, multiple_vals)
 
-    def create_column_from_map_df(
-        self, original_column: str, map_df: pd.DataFrame, multiple_vals: bool
-    ) -> pd.Series:
+    def export_map_df(self):
         """
-        Creates a column 
+        Export dataframe of unique column values and their reconciled QIDs to a CSV file
+        """
+
+        filename = "reconciliation_" + self.table + "_" + get_timestamp() + ".csv"
+
+        self.current_file_path = os.path.join(config.DATA_FOLDER, filename)
+
+        self._map_df.sort_values("count", ascending=False).to_csv(
+            self.current_file_path, sep="\t"
+        )
+
+        logger.info(
+            f"Dataframe of value to entity mappings exported to {self.current_file_path}"
+        )
+
+    def import_map_df(self, file_path: str = None):
+        """
+        Import previously exported CSV of unique column values and their reconciled QIDs.
+
+        Args:
+            file_path (str, optional)
+        """
+
+        if file_path:
+            self._map_df_imported = pd.read_csv(file_path, sep="\t", index_col=0)
+        else:
+            if not hasattr(self, "current_file_path"):
+                raise ValueError(
+                    "Dataframe must be exported first or file_path parameter must be used."
+                )
+
+            self._map_df_imported = pd.read_csv(
+                self.current_file_path, sep="\t", index_col=0
+            )
+
+    def create_column_from_map_df(self, original_column: str) -> pd.Series:
+        """
+        Creates a column
 
         Args:
             original_column (str): column to apply the transform to
-            map_df (pd.DataFrame): dataframe containing unique column values and their mapping to Wikidata entities
-            multiple_vals (bool): whether items in the original dataframe column contain multiple values per element
-                (elements are lists)
 
         Returns:
             pd.Series: transformed column
         """
 
-        if multiple_vals:
-            return self.df[original_column].apply(
+        if self._map_df_imported is not None:
+            map_df = self._map_df_imported
+        elif self._map_df is not None:
+            logger.warn(
+                "Using automatically generated mapping table. It is recommended to run `export_map_df`"
+                "and manually inspect the reconciled entities before adding them back to your data."
+            )
+            map_df = self._map_df
+        else:
+            raise ValueError(
+                "No mapping table has been generated. Run `process_column` first."
+            )
+
+        if self.multiple_vals:
+            new_col = self.df[original_column].progress_apply(
                 lambda x: map_df.loc[
-                    [i for i in x if i != ""], "filtered_qids"
+                    [i for i in x if len(i) > 0], "filtered_qids"
                 ].values.sum()
                 if x != [""]
                 else []
             )
+
+            return new_col.apply(lambda x: [] if str(x) == "[][]" else x)
         else:
-            return self.df[original_column].apply(
+            return self.df[original_column].progress_apply(
                 lambda x: map_df.loc[x, "filtered_qids"] if x != "" else []
             )

--- a/heritageconnector/entity_matching/reconciler.py
+++ b/heritageconnector/entity_matching/reconciler.py
@@ -142,6 +142,7 @@ class reconciler:
                 return_instanceof=False,
                 similarity_thresh=text_similarity_thresh,
                 field_exists_filter=field_exists_filter,
+                return_exact_only=True,
             )
 
             return qids

--- a/heritageconnector/utils/generic.py
+++ b/heritageconnector/utils/generic.py
@@ -3,6 +3,7 @@ import requests
 from itertools import islice
 import shelve
 import functools
+import time
 from typing import List
 
 
@@ -135,3 +136,11 @@ def cache(filename: str):
         return functools.update_wrapper(wrapper, user_function)
 
     return decorating_function
+
+
+def get_timestamp() -> str:
+    """
+    For timestamped filenames
+    """
+
+    return time.strftime("%Y%m%d-%H%M")

--- a/test/test_disambiguation.py
+++ b/test/test_disambiguation.py
@@ -32,3 +32,12 @@ def test_es_text_search():
     assert len(res1) > 0
     assert len(res2) > 0
     assert len(res2) < len(res1)
+    assert len(list(set(res1))) == len(res1)
+    assert len(list(set(res2))) == len(res2)
+
+    # this result will contain 'phonograph' as well without the `return_exact_only` flag
+    res3 = s.run_search(
+        "photograph", return_exact_only=True, field_exists_filter="claims.P279",
+    )
+
+    assert res3 == ["Q125191"]

--- a/test/test_disambiguation.py
+++ b/test/test_disambiguation.py
@@ -1,4 +1,4 @@
-from heritageconnector.disambiguation import retrieve
+from heritageconnector.disambiguation import retrieve, search
 
 
 def test_get_wikidata_fields():
@@ -10,3 +10,25 @@ def test_get_wikidata_fields():
     assert set(res_df.columns.tolist()) == set(
         ["item", "itemLabel", "itemDescription", "altLabel", "P569", "P570"]
     )
+
+
+def test_es_text_search():
+    s = search.es_text_search()
+
+    # this unconstrained search should return many results
+    res1 = s.run_search(
+        "museum", return_instanceof=False, limit=500, similarity_thresh=95
+    )
+
+    # this constrained search should return fewer results, assuming the Wikidata import has not already been filtered by P279
+    res2 = s.run_search(
+        "museum",
+        return_instanceof=False,
+        limit=5000,
+        similarity_thresh=95,
+        field_exists_filter="claims.P279",
+    )
+
+    assert len(res1) > 0
+    assert len(res2) > 0
+    assert len(res2) < len(res1)

--- a/test/test_entity_matching.py
+++ b/test/test_entity_matching.py
@@ -7,6 +7,7 @@ import warnings
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
+import pytest
 import pandas as pd
 from heritageconnector.entity_matching import reconciler
 
@@ -15,7 +16,7 @@ def test_reconciler_process_column():
     data = pd.DataFrame.from_dict({"item_name": ["photograph", "camera", "model"]})
 
     rec = reconciler.reconciler(data, table="OBJECT")
-    result = rec.process_column(
+    rec.process_column(
         "item_name",
         multiple_vals=False,
         class_include="Q223557",
@@ -23,5 +24,9 @@ def test_reconciler_process_column():
         text_similarity_thresh=95,
     )
 
+    with pytest.warns(None) as record:
+        result = rec.create_column_from_map_df("item_name")
+
+    assert len(record) == 1
     assert isinstance(result, pd.Series)
     assert result.values.tolist() == [["Q125191"], ["Q15328"], ["Q57312861"]]

--- a/test/test_entity_matching.py
+++ b/test/test_entity_matching.py
@@ -7,15 +7,17 @@ import warnings
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
+import os
 import pytest
 import pandas as pd
 from heritageconnector.entity_matching import reconciler
 
 
-def test_reconciler_process_column():
+@pytest.fixture
+def rec():
     data = pd.DataFrame.from_dict({"item_name": ["photograph", "camera", "model"]})
-
     rec = reconciler.reconciler(data, table="OBJECT")
+
     rec.process_column(
         "item_name",
         multiple_vals=False,
@@ -24,9 +26,23 @@ def test_reconciler_process_column():
         text_similarity_thresh=95,
     )
 
+    return rec
+
+
+def test_reconciler_process_column(rec):
     with pytest.warns(None) as record:
         result = rec.create_column_from_map_df("item_name")
 
     assert len(record) == 1
     assert isinstance(result, pd.Series)
     assert result.values.tolist() == [["Q125191"], ["Q15328"], ["Q57312861"]]
+
+
+def test_reconciler_import_export(rec):
+    rec.export_map_df("./test_data.csv")
+    rec.import_map_df("./test_data.csv")
+    os.remove(rec.current_file_path)
+
+    # both qids and filtered_qids columns should be of type list
+    assert all(isinstance(i, list) for i in rec._map_df_imported["qids"])
+    assert all(isinstance(i, list) for i in rec._map_df_imported["filtered_qids"])


### PR DESCRIPTION
Reconciled people and organisation types added to the ES index. Closes #124 

---

**📈  stats:**
- 32% of organisations have at least one resolved type
- 51% of objects have at least one resolved type

---

**⏰  future considerations:**
- the reconciler checks text similarity but only for the Wikidata labels field. This should be expanded to aliases: #138 
- some of these types are wrong and some are missing due to me having to go through the unique types and correct/add to them. Hopefully the ML classifier should take care of this incorrectness well enough, but I can go back and improve the matches if not. We could build a simple system to automatically surface these and propagate human-labelled types, e.g. '35mm camera' given Wikidata entity Q(Camera) could propagate to 'film camera' etc automatically. See #139 
- the same mechanism could be used to add people's occupations to the graph but I haven't done it yet. See #140